### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
         "perl" : "6.c",
         "name" : "Time::Crontab",
+        "license" : "Artistic-2.0",
         "version" : "0.1.0",
         "description" : "Time::Crontab for Perl6 - Parses Crontab Specifications",
         "authors" : ["Martin Barth <martin@senfdax.de>"],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license